### PR TITLE
Register `put-live`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/contracts": "^8.37",
-        "spatie/laravel-event-sourcing": "^4.7|^5",
+        "spatie/laravel-event-sourcing": "^5",
         "spatie/laravel-package-tools": "^1.4.3"
     },
     "require-dev": {

--- a/src/ZeroDowntimeEventReplaysServiceProvider.php
+++ b/src/ZeroDowntimeEventReplaysServiceProvider.php
@@ -5,6 +5,7 @@ namespace Gosuperscript\ZeroDowntimeEventReplays;
 use Gosuperscript\ZeroDowntimeEventReplays\Commands\CreateReplay;
 use Gosuperscript\ZeroDowntimeEventReplays\Commands\DeleteReplay;
 use Gosuperscript\ZeroDowntimeEventReplays\Commands\EnableLiveProjection;
+use Gosuperscript\ZeroDowntimeEventReplays\Commands\PutReplayLive;
 use Gosuperscript\ZeroDowntimeEventReplays\Commands\ReplayCommand;
 use Gosuperscript\ZeroDowntimeEventReplays\Repositories\RedisReplayRepository;
 use Gosuperscript\ZeroDowntimeEventReplays\Repositories\ReplayRepository;
@@ -23,7 +24,8 @@ class ZeroDowntimeEventReplaysServiceProvider extends PackageServiceProvider
                 CreateReplay::class,
                 DeleteReplay::class,
                 ReplayCommand::class,
-                EnableLiveProjection::class
+                EnableLiveProjection::class,
+                PutReplayLive::class,
             );
     }
 

--- a/tests/Fakes/FakeProjectionist.php
+++ b/tests/Fakes/FakeProjectionist.php
@@ -8,12 +8,11 @@ use Spatie\EventSourcing\Projectionist;
 
 class FakeProjectionist extends Projectionist
 {
-    public array $projectors = [];
-
     public array $replays = [];
 
     public function __construct()
     {
+        parent::__construct(['catch_exceptions' => false]);
     }
 
     public function addProjector($projector, ?Projector $class = null): Projectionist

--- a/tests/Fakes/FakeStoredEventRepository.php
+++ b/tests/Fakes/FakeStoredEventRepository.php
@@ -55,4 +55,9 @@ class FakeStoredEventRepository implements StoredEventRepository
     {
         $this->countsStartingFrom[$startingFrom] = $count;
     }
+
+    public function find(int $id): StoredEvent
+    {
+        // TODO: Implement find() method.
+    }
 }


### PR DESCRIPTION
Adds missing register of `\Gosuperscript\ZeroDowntimeEventReplays\Commands\PutReplayLive` command in service provider.

Also fixes compatibility with `spatie/laravel-event-sourcing` `v5` and removes support for `v4`.